### PR TITLE
Fix tests after Instadapp team changes

### DIFF
--- a/contracts/mainnet/connectors/liquity/events.sol
+++ b/contracts/mainnet/connectors/liquity/events.sol
@@ -8,8 +8,8 @@ contract Events {
         uint maxFeePercentage,
         uint depositAmount,
         uint borrowAmount,
-        uint[] getIds,
-        uint[] setIds
+        uint256[] getIds,
+        uint256[] setIds
     );
     event LogClose(address indexed borrower, uint setId);
     event LogDeposit(address indexed borrower, uint amount, uint getId, uint setId);
@@ -23,8 +23,8 @@ contract Events {
         uint withdrawAmount,
         uint borrowAmount,
         uint repayAmount,
-        uint[] getIds,
-        uint[] setIds
+        uint256[] getIds,
+        uint256[] setIds
     );
     event LogClaimCollateralFromRedemption(address indexed borrower, uint amount, uint setId);
 
@@ -52,7 +52,7 @@ contract Events {
     event LogStabilityMoveEthGainToTrove(address indexed borrower, uint amount);
 
     /* Staking */
-    event LogStake(address indexed borrower, uint amount, uint setStakeId, uint getStakeId, uint setEthGainId, uint setLusdGainId);
+    event LogStake(address indexed borrower, uint amount, uint getStakeId, uint setStakeId, uint setEthGainId, uint setLusdGainId);
     event LogUnstake(address indexed borrower, uint amount, uint getUnstakeId, uint setUnstakeId, uint setEthGainId, uint setLusdGainId);
     event LogClaimStakingGains(address indexed borrower, uint ethGain, uint lusdGain, uint setEthGainId, uint setLusdGainId);
 }

--- a/contracts/mainnet/connectors/liquity/events.sol
+++ b/contracts/mainnet/connectors/liquity/events.sol
@@ -8,14 +8,14 @@ contract Events {
         uint maxFeePercentage,
         uint depositAmount,
         uint borrowAmount,
-        uint getId,
-        uint setId
+        uint[] getIds,
+        uint[] setIds
     );
     event LogClose(address indexed borrower, uint setId);
-    event LogDeposit(address indexed borrower, uint amount, uint getId);
-    event LogWithdraw(address indexed borrower, uint amount, uint setId);
-    event LogBorrow(address indexed borrower, uint amount, uint setId);
-    event LogRepay(address indexed borrower, uint amount, uint getId);
+    event LogDeposit(address indexed borrower, uint amount, uint getId, uint setId);
+    event LogWithdraw(address indexed borrower, uint amount, uint getId, uint setId);
+    event LogBorrow(address indexed borrower, uint amount, uint getId, uint setId);
+    event LogRepay(address indexed borrower, uint amount, uint getId, uint setId);
     event LogAdjust(
         address indexed borrower,
         uint maxFeePercentage,

--- a/contracts/mainnet/connectors/liquity/events.sol
+++ b/contracts/mainnet/connectors/liquity/events.sol
@@ -38,6 +38,7 @@ contract Events {
         uint lqtyGain,
         address frontendTag,
         uint getDepositId,
+        uint setDepositId,
         uint setEthGainId,
         uint setLqtyGainId
     );
@@ -45,6 +46,7 @@ contract Events {
         uint amount,
         uint ethGain,
         uint lqtyGain,
+        uint getWithdrawId,
         uint setWithdrawId,
         uint setEthGainId,
         uint setLqtyGainId
@@ -52,7 +54,7 @@ contract Events {
     event LogStabilityMoveEthGainToTrove(address indexed borrower, uint amount);
 
     /* Staking */
-    event LogStake(address indexed borrower, uint amount, uint getStakeId, uint setEthGainId, uint setLusdGainId);
-    event LogUnstake(address indexed borrower, uint amount, uint setUnstakeId, uint setEthGainId, uint setLusdGainId);
+    event LogStake(address indexed borrower, uint amount, uint setStakeId, uint getStakeId, uint setEthGainId, uint setLusdGainId);
+    event LogUnstake(address indexed borrower, uint amount, uint getUnstakeId, uint setUnstakeId, uint setEthGainId, uint setLusdGainId);
     event LogClaimStakingGains(address indexed borrower, uint ethGain, uint lusdGain, uint setEthGainId, uint setLusdGainId);
 }

--- a/contracts/mainnet/connectors/liquity/events.sol
+++ b/contracts/mainnet/connectors/liquity/events.sol
@@ -23,10 +23,8 @@ contract Events {
         uint withdrawAmount,
         uint borrowAmount,
         uint repayAmount,
-        uint getDepositId,
-        uint setWithdrawId,
-        uint getRepayId,
-        uint setBorrowId
+        uint[] getIds,
+        uint[] setIds
     );
     event LogClaimCollateralFromRedemption(address indexed borrower, uint amount, uint setId);
 

--- a/contracts/mainnet/connectors/liquity/helpers.sol
+++ b/contracts/mainnet/connectors/liquity/helpers.sol
@@ -3,4 +3,35 @@ pragma solidity ^0.7.6;
 import { DSMath } from "../../common/math.sol";
 import { Basic } from "../../common/basic.sol";
 
-abstract contract Helpers is DSMath, Basic {}
+import { TokenInterface } from "../../common/interfaces.sol";
+
+import {
+    BorrowerOperationsLike,
+    TroveManagerLike,
+    StabilityPoolLike,
+    StakingLike,
+    CollateralSurplusLike,
+    LqtyTokenLike
+} from "./interface.sol";
+
+abstract contract Helpers is DSMath, Basic {
+
+    BorrowerOperationsLike internal constant borrowerOperations = BorrowerOperationsLike(0x24179CD81c9e782A4096035f7eC97fB8B783e007);
+    TroveManagerLike internal constant troveManager = TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
+    StabilityPoolLike internal constant stabilityPool = StabilityPoolLike(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
+    StakingLike internal constant staking = StakingLike(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
+    CollateralSurplusLike internal constant collateralSurplus = CollateralSurplusLike(0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521);
+    LqtyTokenLike internal constant lqtyToken = LqtyTokenLike(0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D);
+    TokenInterface internal constant lusdToken = TokenInterface(0x5f98805A4E8be255a32880FDeC7F6728C6568bA0);
+    
+    // Prevents stack-too-deep error
+    struct AdjustTrove {
+        uint maxFeePercentage;
+        uint withdrawAmount;
+        uint depositAmount;
+        uint borrowAmount;
+        uint repayAmount;
+        bool isBorrow;
+    }
+
+}

--- a/contracts/mainnet/connectors/liquity/interface.sol
+++ b/contracts/mainnet/connectors/liquity/interface.sol
@@ -54,6 +54,7 @@ interface StabilityPoolLike {
     function withdrawETHGainToTrove(address _upperHint, address _lowerHint) external;
     function getDepositorETHGain(address _depositor) external view returns (uint);
     function getDepositorLQTYGain(address _depositor) external view returns (uint);
+    function getCompoundedLUSDDeposit(address _depositor) external view returns (uint);
 }
 
 interface StakingLike {
@@ -61,6 +62,7 @@ interface StakingLike {
     function unstake(uint _LQTYamount) external;
     function getPendingETHGain(address _user) external view returns (uint);
     function getPendingLUSDGain(address _user) external view returns (uint);
+    function stakes(address owner) external view returns (uint);
 }
 
 interface CollateralSurplusLike { 

--- a/contracts/mainnet/connectors/liquity/main.sol
+++ b/contracts/mainnet/connectors/liquity/main.sol
@@ -38,8 +38,8 @@ abstract contract LiquityResolver is Events, Helpers {
         uint borrowAmount,
         address upperHint,
         address lowerHint,
-        uint[] getIds,
-        uint[] setIds
+        uint[] memory getIds,
+        uint[] memory setIds
     ) external payable returns (string memory _eventName, bytes memory _eventParam) {
 
         depositAmount = getUint(getIds[0], depositAmount);
@@ -139,7 +139,8 @@ abstract contract LiquityResolver is Events, Helpers {
      * @param amount Amount of LUSD to borrow
      * @param upperHint Address of the Trove near the upper bound of where the user's Trove should now sit in the ordered Trove list
      * @param lowerHint Address of the Trove near the lower bound of where the user's Trove should now sit in the ordered Trove list
-     * @param setId Optional storage slot to store the borrowed LUSD in
+     * @param getId Optional storage slot to retrieve the amount of LUSD to borrow
+     * @param setId Optional storage slot to store the final amount of LUSD borrowed
     */
     function borrow(
         uint maxFeePercentage,
@@ -165,7 +166,8 @@ abstract contract LiquityResolver is Events, Helpers {
      * @param amount Amount of LUSD to repay
      * @param upperHint Address of the Trove near the upper bound of where the user's Trove should now sit in the ordered Trove list
      * @param lowerHint Address of the Trove near the lower bound of where the user's Trove should now sit in the ordered Trove list
-     * @param getId Optional storage slot to retrieve the LUSD from
+     * @param getId Optional storage slot to retrieve the amount of LUSD from
+     * @param setId Optional storage slot to store the final amount of LUSD repaid
     */
     function repay(
         uint amount,
@@ -211,8 +213,8 @@ abstract contract LiquityResolver is Events, Helpers {
         uint repayAmount,
         address upperHint,
         address lowerHint,
-        uint[] getIds,
-        uint[] setIds
+        uint[] memory getIds,
+        uint[] memory setIds
     ) external payable returns (string memory _eventName, bytes memory _eventParam) {
         AdjustTrove memory adjustTrove;
 
@@ -276,7 +278,8 @@ abstract contract LiquityResolver is Events, Helpers {
      * @notice Deposit LUSD into Stability Pool
      * @param amount Amount of LUSD to deposit into Stability Pool
      * @param frontendTag Address of the frontend to make this deposit against (determines the kickback rate of rewards)
-     * @param getDepositId Optional storage slot to retrieve the LUSD from
+     * @param getDepositId Optional storage slot to retrieve the amount of LUSD from
+     * @param setDepositId Optional storage slot to store the final amount of LUSD deposited
      * @param setEthGainId Optional storage slot to store any ETH gains in
      * @param setLqtyGainId Optional storage slot to store any LQTY gains in
     */
@@ -312,6 +315,7 @@ abstract contract LiquityResolver is Events, Helpers {
      * @dev Withdraw user deposited LUSD from Stability Pool
      * @notice Withdraw LUSD from Stability Pool
      * @param amount Amount of LUSD to withdraw from Stability Pool
+     * @param getWithdrawId Optional storage slot to retrieve the amount of LUSD to withdraw from
      * @param setWithdrawId Optional storage slot to store the withdrawn LUSD
      * @param setEthGainId Optional storage slot to store any ETH gains in
      * @param setLqtyGainId Optional storage slot to store any LQTY gains in
@@ -325,7 +329,7 @@ abstract contract LiquityResolver is Events, Helpers {
     ) external returns (string memory _eventName, bytes memory _eventParam) {
         amount = getUint(getWithdrawId, amount);
 
-        amount = amount == uint(-1) ? StabilityPoolLike.getCompoundedLUSDDeposit(address(this)) : amount;
+        amount = amount == uint(-1) ? stabilityPool.getCompoundedLUSDDeposit(address(this)) : amount;
 
         uint ethGain = stabilityPool.getDepositorETHGain(address(this));
         uint lqtyBalanceBefore = lqtyToken.balanceOf(address(this));
@@ -366,7 +370,8 @@ abstract contract LiquityResolver is Events, Helpers {
      * @dev Sends LQTY tokens from user to Staking Pool
      * @notice Stake LQTY in Staking Pool
      * @param amount Amount of LQTY to stake
-     * @param getStakeId Optional storage slot to retrieve the LQTY from
+     * @param getStakeId Optional storage slot to retrieve the amount of LQTY to stake
+     * @param setStakeId Optional storage slot to store the final staked amount (can differ if requested with max balance: uint(-1))
      * @param setEthGainId Optional storage slot to store any ETH gains
      * @param setLusdGainId Optional storage slot to store any LUSD gains
     */
@@ -396,7 +401,8 @@ abstract contract LiquityResolver is Events, Helpers {
      * @dev Sends LQTY tokens from Staking Pool to user
      * @notice Unstake LQTY in Staking Pool
      * @param amount Amount of LQTY to unstake
-     * @param setStakeId Optional storage slot to store the unstaked LQTY
+     * @param getUnstakeId Optional storage slot to retrieve the amount of LQTY to unstake
+     * @param setUnstakeId Optional storage slot to store the unstaked LQTY
      * @param setEthGainId Optional storage slot to store any ETH gains
      * @param setLusdGainId Optional storage slot to store any LUSD gains
     */

--- a/contracts/mainnet/connectors/liquity/main.sol
+++ b/contracts/mainnet/connectors/liquity/main.sol
@@ -251,7 +251,7 @@ abstract contract LiquityResolver is Events, Helpers {
         setUint(setIds[3], adjustTrove.repayAmount);
 
         _eventName = "LogAdjust(address,uint256,uint256,uint256,uint256,uint256,uint256[],uint256[])";
-        _eventParam = abi.encode(address(this), maxFeePercentage, depositAmount, withdrawAmount, borrowAmount, repayAmount, getIds, setIds);
+        _eventParam = abi.encode(address(this), maxFeePercentage, adjustTrove.depositAmount, adjustTrove.withdrawAmount, adjustTrove.borrowAmount, adjustTrove.repayAmount, getIds, setIds);
     }
 
     /**

--- a/contracts/mainnet/connectors/liquity/main.sol
+++ b/contracts/mainnet/connectors/liquity/main.sol
@@ -245,10 +245,10 @@ abstract contract LiquityResolver is Events, Helpers {
             lowerHint
         );
         
-        setUint(setIds[0], depositAmount);
-        setUint(setIds[1], withdrawAmount);
-        setUint(setIds[2], borrowAmount);
-        setUint(setIds[3], repayAmount);
+        setUint(setIds[0], adjustTrove.depositAmount);
+        setUint(setIds[1], adjustTrove.withdrawAmount);
+        setUint(setIds[2], adjustTrove.borrowAmount);
+        setUint(setIds[3], adjustTrove.repayAmount);
 
         _eventName = "LogAdjust(address,uint256,uint256,uint256,uint256,uint256,uint256[],uint256[])";
         _eventParam = abi.encode(address(this), maxFeePercentage, depositAmount, withdrawAmount, borrowAmount, repayAmount, getIds, setIds);

--- a/test/liquity/liquity.helpers.js
+++ b/test/liquity/liquity.helpers.js
@@ -50,10 +50,11 @@ const openTroveSpell = async (
       borrowAmount,
       upperHint,
       lowerHint,
-      0,
-      0,
+      [0, 0],
+      [0, 0],
     ],
   };
+
   return await dsa
     .connect(signer)
     .cast(...encodeSpells([openTroveSpell]), address, {

--- a/test/liquity/liquity.test.js
+++ b/test/liquity/liquity.test.js
@@ -65,8 +65,8 @@ describe("Liquity", () => {
               borrowAmount,
               upperHint,
               lowerHint,
-              0,
-              0,
+              [0, 0],
+              [0, 0],
             ],
           };
 
@@ -144,8 +144,8 @@ describe("Liquity", () => {
               borrowAmount,
               upperHint,
               lowerHint,
-              depositId,
-              0,
+              [depositId, 0],
+              [0, 0],
             ],
           };
 
@@ -218,8 +218,8 @@ describe("Liquity", () => {
               borrowAmount,
               upperHint,
               lowerHint,
-              0,
-              borrowId,
+              [0, 0],
+              [borrowId, 0],
             ],
           };
 
@@ -297,8 +297,8 @@ describe("Liquity", () => {
               borrowAmount,
               upperHint,
               lowerHint,
-              0,
-              0,
+              [0, 0],
+              [0, 0],
             ],
           };
 
@@ -313,17 +313,24 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           expect(castLogEvent.eventNames[0]).eq(
-            "LogOpen(address,uint256,uint256,uint256,uint256,uint256)"
+            "LogOpen(address,uint256,uint256,uint256,uint256[],uint256[])"
           );
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256", "uint256", "uint256", "uint256"],
             [
-              userWallet.address,
+              "address",
+              "uint256",
+              "uint256",
+              "uint256",
+              "uint256[]",
+              "uint256[]",
+            ],
+            [
+              dsa.address,
               maxFeePercentage,
               depositAmount,
               borrowAmount,
-              0,
-              0,
+              [0, 0],
+              [0, 0],
             ]
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
@@ -598,7 +605,7 @@ describe("Liquity", () => {
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
             ["address", "uint256"],
-            [userWallet.address, 0]
+            [dsa.address, 0]
           );
           expect(castLogEvent.eventNames[0]).eq("LogClose(address,uint256)");
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
@@ -620,7 +627,7 @@ describe("Liquity", () => {
           const depositEthSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "deposit",
-            args: [topupAmount, upperHint, lowerHint, 0],
+            args: [topupAmount, upperHint, lowerHint, 0, 0],
           };
 
           await dsa
@@ -663,7 +670,7 @@ describe("Liquity", () => {
           const depositEthToTroveSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "deposit",
-            args: [0, upperHint, lowerHint, depositId],
+            args: [0, upperHint, lowerHint, depositId, 0],
           };
           const spells = [depositEthSpell, depositEthToTroveSpell];
 
@@ -697,7 +704,7 @@ describe("Liquity", () => {
           const depositEthSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "deposit",
-            args: [topupAmount, upperHint, lowerHint, 0],
+            args: [topupAmount, upperHint, lowerHint, 0, 0],
           };
 
           const depositTx = await dsa
@@ -710,11 +717,11 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256"],
-            [userWallet.address, topupAmount, 0]
+            ["address", "uint256", "uint256", "uint256"],
+            [dsa.address, topupAmount, 0, 0]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogDeposit(address,uint256,uint256)"
+            "LogDeposit(address,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -734,7 +741,7 @@ describe("Liquity", () => {
           const withdrawEthSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "withdraw",
-            args: [withdrawAmount, upperHint, lowerHint, 0],
+            args: [withdrawAmount, upperHint, lowerHint, 0, 0],
           };
 
           await dsa
@@ -772,7 +779,7 @@ describe("Liquity", () => {
           const withdrawEthFromTroveSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "withdraw",
-            args: [withdrawAmount, upperHint, lowerHint, withdrawId],
+            args: [withdrawAmount, upperHint, lowerHint, 0, withdrawId],
           };
 
           const withdrawEthSpell = {
@@ -815,11 +822,10 @@ describe("Liquity", () => {
           const withdrawAmount = ethers.utils.parseEther("1");
           const upperHint = ethers.constants.AddressZero;
           const lowerHint = ethers.constants.AddressZero;
-          const setId = 0;
           const withdrawEthSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "withdraw",
-            args: [withdrawAmount, upperHint, lowerHint, setId],
+            args: [withdrawAmount, upperHint, lowerHint, 0, 0],
           };
 
           const withdrawTx = await dsa
@@ -830,11 +836,11 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256"],
-            [userWallet.address, withdrawAmount, setId]
+            ["address", "uint256", "uint256", "uint256"],
+            [dsa.address, withdrawAmount, 0, 0]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogWithdraw(address,uint256,uint256)"
+            "LogWithdraw(address,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -856,7 +862,7 @@ describe("Liquity", () => {
           const borrowSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "borrow",
-            args: [maxFeePercentage, borrowAmount, upperHint, lowerHint, 0],
+            args: [maxFeePercentage, borrowAmount, upperHint, lowerHint, 0, 0],
           };
 
           // Borrow more LUSD from the Trove
@@ -896,6 +902,7 @@ describe("Liquity", () => {
               borrowAmount,
               upperHint,
               lowerHint,
+              0,
               borrowId,
             ],
           };
@@ -944,11 +951,10 @@ describe("Liquity", () => {
           const upperHint = ethers.constants.AddressZero;
           const lowerHint = ethers.constants.AddressZero;
           const maxFeePercentage = ethers.utils.parseUnits("0.5", 18); // 0.5% max fee
-          const setId = 0;
           const borrowSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "borrow",
-            args: [maxFeePercentage, borrowAmount, upperHint, lowerHint, setId],
+            args: [maxFeePercentage, borrowAmount, upperHint, lowerHint, 0, 0],
           };
 
           const borrowTx = await dsa
@@ -959,11 +965,11 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256"],
-            [userWallet.address, borrowAmount, setId]
+            ["address", "uint256", "uint256", "uint256"],
+            [dsa.address, borrowAmount, 0, 0]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogBorrow(address,uint256,uint256)"
+            "LogBorrow(address,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -997,7 +1003,7 @@ describe("Liquity", () => {
           const repaySpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "repay",
-            args: [repayAmount, upperHint, lowerHint, 0],
+            args: [repayAmount, upperHint, lowerHint, 0, 0],
           };
 
           await dsa
@@ -1061,7 +1067,7 @@ describe("Liquity", () => {
           const borrowSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "repay",
-            args: [0, upperHint, lowerHint, lusdDepositId],
+            args: [0, upperHint, lowerHint, lusdDepositId, 0],
           };
 
           const spells = [depositSpell, borrowSpell];
@@ -1099,12 +1105,11 @@ describe("Liquity", () => {
             borrowAmount,
             liquity
           );
-          const getId = 0;
 
           const borrowSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "repay",
-            args: [repayAmount, upperHint, lowerHint, getId],
+            args: [repayAmount, upperHint, lowerHint, 0, 0],
           };
 
           const repayTx = await dsa
@@ -1117,11 +1122,11 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256"],
-            [userWallet.address, repayAmount, getId]
+            ["address", "uint256", "uint256", "uint256"],
+            [dsa.address, repayAmount, 0, 0]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogRepay(address,uint256,uint256)"
+            "LogRepay(address,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -1151,16 +1156,14 @@ describe("Liquity", () => {
             method: "adjust",
             args: [
               maxFeePercentage,
-              withdrawAmount,
               depositAmount,
+              withdrawAmount,
               borrowAmount,
               repayAmount,
               upperHint,
               lowerHint,
-              0,
-              0,
-              0,
-              0,
+              [0, 0, 0, 0],
+              [0, 0, 0, 0],
             ],
           };
 
@@ -1218,16 +1221,14 @@ describe("Liquity", () => {
             method: "adjust",
             args: [
               maxFeePercentage,
-              withdrawAmount,
               depositAmount,
+              withdrawAmount,
               borrowAmount,
               repayAmount,
               upperHint,
               lowerHint,
-              0,
-              0,
-              0,
-              0,
+              [0, 0, 0, 0],
+              [0, 0, 0, 0],
             ],
           };
 
@@ -1297,16 +1298,14 @@ describe("Liquity", () => {
             method: "adjust",
             args: [
               maxFeePercentage,
-              withdrawAmount,
               0, // Deposit amount comes from a previous spell's storage slot
+              withdrawAmount,
               borrowAmount,
               0, // Repay amount comes from a previous spell's storage slot
               upperHint,
               lowerHint,
-              ethDepositId,
-              0,
-              lusdRepayId,
-              0,
+              [ethDepositId, 0, 0, 0],
+              [0, 0, 0, 0],
             ],
           };
           const spells = [depositEthSpell, depositLusdSpell, adjustSpell];
@@ -1379,16 +1378,14 @@ describe("Liquity", () => {
             method: "adjust",
             args: [
               maxFeePercentage,
-              withdrawAmount,
               depositAmount,
+              withdrawAmount,
               borrowAmount,
               repayAmount,
               upperHint,
               lowerHint,
-              0,
-              ethWithdrawId,
-              0,
-              lusdBorrowId,
+              [0, 0, 0, 0],
+              [0, ethWithdrawId, lusdBorrowId, 0],
             ],
           };
 
@@ -1432,7 +1429,6 @@ describe("Liquity", () => {
           const userLusdBalanceAfter = await liquity.lusdToken.balanceOf(
             userWallet.address
           );
-
           expect(userEthBalanceAfter).eq(
             userEthBalanceBefore.add(withdrawAmount)
           );
@@ -1452,26 +1448,20 @@ describe("Liquity", () => {
           const upperHint = ethers.constants.AddressZero;
           const lowerHint = ethers.constants.AddressZero;
           const maxFeePercentage = ethers.utils.parseUnits("0.5", 18); // 0.5% max fee
-          const getDepositId = 0;
-          const setWithdrawId = 0;
-          const getRepayId = 0;
-          const setBorrowId = 0;
 
           const adjustSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "adjust",
             args: [
               maxFeePercentage,
-              withdrawAmount,
               depositAmount,
+              withdrawAmount,
               borrowAmount,
               repayAmount,
               upperHint,
               lowerHint,
-              getDepositId,
-              setWithdrawId,
-              getRepayId,
-              setBorrowId,
+              [0, 0, 0, 0],
+              [0, 0, 0, 0],
             ],
           };
 
@@ -1493,26 +1483,22 @@ describe("Liquity", () => {
               "uint256",
               "uint256",
               "uint256",
-              "uint256",
-              "uint256",
-              "uint256",
-              "uint256",
+              "uint256[]",
+              "uint256[]",
             ],
             [
-              userWallet.address,
+              dsa.address,
               maxFeePercentage,
               depositAmount,
               withdrawAmount,
               borrowAmount,
               repayAmount,
-              getDepositId,
-              setWithdrawId,
-              getRepayId,
-              setBorrowId,
+              [0, 0, 0, 0],
+              [0, 0, 0, 0],
             ]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogAdjust(address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"
+            "LogAdjust(address,uint256,uint256,uint256,uint256,uint256,uint256[],uint256[])"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -1652,7 +1638,7 @@ describe("Liquity", () => {
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
             ["address", "uint256", "uint256"],
-            [userWallet.address, claimAmount, setId]
+            [dsa.address, claimAmount, setId]
           );
           expect(castLogEvent.eventNames[0]).eq(
             "LogClaimCollateralFromRedemption(address,uint256,uint256)"
@@ -1678,7 +1664,7 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           await dsa
@@ -1711,7 +1697,7 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [0, frontendTag, lusdDepositId, 0, 0],
+            args: [0, frontendTag, lusdDepositId, 0, 0, 0],
           };
           const spells = [depositLusdSpell, stabilityDepositSpell];
 
@@ -1735,6 +1721,7 @@ describe("Liquity", () => {
           const halfAmount = amount.div(2);
           const frontendTag = ethers.constants.AddressZero;
           const getDepositId = 0;
+          const setDepositId = 0;
           const setEthGainId = 0;
           const setLqtyGainId = 0;
 
@@ -1748,7 +1735,14 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [halfAmount, frontendTag, getDepositId, 0, 0],
+            args: [
+              halfAmount,
+              frontendTag,
+              getDepositId,
+              setDepositId,
+              setEthGainId,
+              setLqtyGainId,
+            ],
           };
 
           // Create a Stability deposit for this DSA
@@ -1803,20 +1797,22 @@ describe("Liquity", () => {
               "uint256",
               "uint256",
               "uint256",
+              "uint256",
             ],
             [
-              userWallet.address,
+              dsa.address,
               halfAmount,
               ethGain,
               lqtyGain,
               frontendTag,
               getDepositId,
+              setDepositId,
               setEthGainId,
               setLqtyGainId,
             ]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogStabilityDeposit(address,uint256,uint256,uint256,address,uint256,uint256,uint256)"
+            "LogStabilityDeposit(address,uint256,uint256,uint256,address,uint256,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -1849,14 +1845,14 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           // Withdraw half of the deposit
           const stabilityWithdrawSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityWithdraw",
-            args: [amount.div(2), 0, 0, 0],
+            args: [amount.div(2), 0, 0, 0, 0],
           };
           const spells = [stabilityDepositSpell, stabilityWithdrawSpell];
 
@@ -1899,14 +1895,14 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           // Withdraw half of the deposit
           const stabilityWithdrawSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityWithdraw",
-            args: [amount.div(2), 0, 0, withdrawId],
+            args: [amount.div(2), 0, 0, 0, withdrawId],
           };
 
           const withdrawLusdSpell = {
@@ -1962,11 +1958,12 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           // Withdraw half of the deposit
           const withdrawAmount = amount.div(2);
+          const getWithdrawId = 0;
           const setWithdrawId = 0;
           const setEthGainId = 0;
           const setLqtyGainId = 0;
@@ -2009,7 +2006,13 @@ describe("Liquity", () => {
           const stabilityWithdrawSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityWithdraw",
-            args: [withdrawAmount, setWithdrawId, setEthGainId, setLqtyGainId],
+            args: [
+              withdrawAmount,
+              getWithdrawId,
+              setWithdrawId,
+              setEthGainId,
+              setLqtyGainId,
+            ],
           };
 
           const withdrawTx = await dsa
@@ -2031,19 +2034,21 @@ describe("Liquity", () => {
               "uint256",
               "uint256",
               "uint256",
+              "uint256",
             ],
             [
-              userWallet.address,
+              dsa.address,
               withdrawAmount,
               ethGain,
               lqtyGain,
+              getWithdrawId,
               setWithdrawId,
               setEthGainId,
               setLqtyGainId,
             ]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogStabilityWithdraw(address,uint256,uint256,uint256,uint256,uint256,uint256)"
+            "LogStabilityWithdraw(address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -2072,7 +2077,7 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2125,7 +2130,7 @@ describe("Liquity", () => {
           const stabilityDepositSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stabilityDeposit",
-            args: [amount, frontendTag, 0, 0, 0],
+            args: [amount, frontendTag, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2160,7 +2165,7 @@ describe("Liquity", () => {
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
             ["address", "uint256"],
-            [userWallet.address, ethGainFromLiquidation]
+            [dsa.address, ethGainFromLiquidation]
           );
           expect(castLogEvent.eventNames[0]).eq(
             "LogStabilityMoveEthGainToTrove(address,uint256)"
@@ -2188,7 +2193,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2228,7 +2233,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [0, lqtyDepositId, lqtyDepositId, 0],
+            args: [0, lqtyDepositId, 0, 0, 0],
           };
           const spells = [depositSpell, stakeSpell];
 
@@ -2262,12 +2267,13 @@ describe("Liquity", () => {
           );
 
           const getStakeId = 0;
+          const setStakeId = 0;
           const setEthGainId = 0;
           const setLusdGainId = 0;
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, getStakeId, setEthGainId, setLusdGainId],
+            args: [amount, getStakeId, setStakeId, setEthGainId, setLusdGainId],
           };
 
           const stakeTx = await dsa
@@ -2279,17 +2285,18 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256", "uint256", "uint256"],
+            ["address", "uint256", "uint256", "uint256", "uint256", "uint256"],
             [
-              userWallet.address,
+              dsa.address,
               amount,
               getStakeId,
+              setStakeId,
               setEthGainId,
               setLusdGainId,
             ]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogStake(address,uint256,uint256,uint256,uint256)"
+            "LogStake(address,uint256,uint256,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
@@ -2308,7 +2315,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2321,7 +2328,7 @@ describe("Liquity", () => {
           const unstakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "unstake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2351,7 +2358,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
 
           await dsa
@@ -2365,7 +2372,7 @@ describe("Liquity", () => {
           const unstakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "unstake",
-            args: [amount, withdrawId, 0, 0],
+            args: [amount, 0, withdrawId, 0, 0],
           };
 
           const withdrawLqtySpell = {
@@ -2410,20 +2417,27 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
 
           await dsa
             .connect(userWallet)
             .cast(...encodeSpells([stakeSpell]), userWallet.address);
 
+          const getUnstakeId = 0;
           const setUnstakeId = 0;
           const setEthGainId = 0;
           const setLusdGainId = 0;
           const unstakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "unstake",
-            args: [amount, setUnstakeId, setEthGainId, setLusdGainId],
+            args: [
+              amount,
+              getUnstakeId,
+              setUnstakeId,
+              setEthGainId,
+              setLusdGainId,
+            ],
           };
 
           const unstakeTx = await dsa
@@ -2435,24 +2449,25 @@ describe("Liquity", () => {
           const castLogEvent = receipt.events.find((e) => e.event === "LogCast")
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
-            ["address", "uint256", "uint256", "uint256", "uint256"],
+            ["address", "uint256", "uint256", "uint256", "uint256", "uint256"],
             [
-              userWallet.address,
+              dsa.address,
               amount,
+              getUnstakeId,
               setUnstakeId,
               setEthGainId,
               setLusdGainId,
             ]
           );
           expect(castLogEvent.eventNames[0]).eq(
-            "LogUnstake(address,uint256,uint256,uint256,uint256)"
+            "LogUnstake(address,uint256,uint256,uint256,uint256,uint256)"
           );
           expect(castLogEvent.eventParams[0]).eq(expectedEventParams);
         });
       });
 
       describe("claimStakingGains()", () => {
-        it("Claims gains from staking", async () => {
+        it("claims gains from staking", async () => {
           const stakerDsa = await buildDSAv2(userWallet.address);
           const amount = ethers.utils.parseUnits("1000", 18); // 1000 LQTY
 
@@ -2466,7 +2481,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
           await stakerDsa
             .connect(userWallet)
@@ -2520,7 +2535,7 @@ describe("Liquity", () => {
           expect(lusdBalanceAfter).to.eq(lusdGain);
         });
 
-        it("Claims gains from staking and stores them for other spells", async () => {
+        it("claims gains from staking and stores them for other spells", async () => {
           const stakerDsa = await buildDSAv2(userWallet.address);
           const amount = ethers.utils.parseUnits("1000", 18); // 1000 LQTY
 
@@ -2534,7 +2549,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
           await stakerDsa
             .connect(userWallet)
@@ -2634,7 +2649,7 @@ describe("Liquity", () => {
           const stakeSpell = {
             connector: helpers.LIQUITY_CONNECTOR,
             method: "stake",
-            args: [amount, 0, 0, 0],
+            args: [amount, 0, 0, 0, 0],
           };
           await stakerDsa
             .connect(userWallet)
@@ -2680,7 +2695,7 @@ describe("Liquity", () => {
             .args;
           const expectedEventParams = ethers.utils.defaultAbiCoder.encode(
             ["address", "uint256", "uint256", "uint256", "uint256"],
-            [userWallet.address, ethGain, lusdGain, setEthGainId, setLusdGainId]
+            [stakerDsa.address, ethGain, lusdGain, setEthGainId, setLusdGainId]
           );
           expect(castLogEvent.eventNames[0]).eq(
             "LogClaimStakingGains(address,uint256,uint256,uint256,uint256)"


### PR DESCRIPTION
Instadapp made our connector support `uint(-1)` and made the getIds/setIds more idiomatic: https://github.com/liquity/dsa-connectors/pull/2

This PR fixes all the tests that were broken by that change.